### PR TITLE
Make Facebook meta tags use window.locatio.href and og:image:secure_url

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,7 @@ body {
 h1 {
   font-family: 'itc-avant-garde-gothic-pro', Helvetica, Arial, sans-serif;
   font-weight: 700;
-  font-size: 42px;
+  font-size: 40px;
   line-height: 58px;
   margin-top: 0;
 }

--- a/src/layout/head.js
+++ b/src/layout/head.js
@@ -142,7 +142,7 @@ class Head extends React.Component{
         <meta prefix="og: http://ogp.me/ns#" property="og:type"         content="website" />
         <meta prefix="og: http://ogp.me/ns#" property="og:title"        content={headline} />
         <meta prefix="og: http://ogp.me/ns#" property="og:description"  content={description} />
-        <meta prefix="og: http://ogp.me/ns#" property="og:image"        content={`${dynamicUrl}/socialimages/${image}`} />
+        <meta prefix="og: http://ogp.me/ns#" property="og:image"        content={`${dynamicUrl}socialimages/${image}`} />
         <meta prefix="og: http://ogp.me/ns#" property="og:image:secure_url"        content={"https://www.ourgovernment.fyi/socialimages/" + image} />
         <meta prefix="og: http://ogp.me/ns#" property="og:locale"       content="en_US" />
         <meta prefix="og: http://ogp.me/ns#" property="fb:app_id"       content="1134187086655814" />

--- a/src/layout/head.js
+++ b/src/layout/head.js
@@ -127,6 +127,9 @@ class Head extends React.Component{
   }
   render() {
     const {title, url, description, headline, image, pageType} = this.props;
+
+    const dynamicUrl = window.location.href;
+
     return(
       <Helmet>
         <title>{title}</title>
@@ -139,7 +142,8 @@ class Head extends React.Component{
         <meta prefix="og: http://ogp.me/ns#" property="og:type"         content="website" />
         <meta prefix="og: http://ogp.me/ns#" property="og:title"        content={headline} />
         <meta prefix="og: http://ogp.me/ns#" property="og:description"  content={description} />
-        <meta prefix="og: http://ogp.me/ns#" property="og:image"        content={"https://www.ourgovernment.fyi/socialimages/" + image} />
+        <meta prefix="og: http://ogp.me/ns#" property="og:image"        content={`${dynamicUrl}/socialimages/${image}`} />
+        <meta prefix="og: http://ogp.me/ns#" property="og:image:secure_url"        content={"https://www.ourgovernment.fyi/socialimages/" + image} />
         <meta prefix="og: http://ogp.me/ns#" property="og:locale"       content="en_US" />
         <meta prefix="og: http://ogp.me/ns#" property="fb:app_id"       content="1134187086655814" />
 


### PR DESCRIPTION
I was getting the following error when I tried using the sharing debugger:

`
Provided og:image URL, https://www.ourgovernment.fyi/socialimages/general-2.png could not be processed as an image because it has an invalid content type.
`

this SO answer said I should use secure_url:

https://stackoverflow.com/questions/8855361/fb-opengraph-ogimage-not-pulling-images-possibly-https

https://ogp.me/#structured