### PR TITLE
Adds sources to /seniors page content, also removes HOMEOWNER demographics

### DIFF
--- a/src/data/PartyPlatformDataSeniors.js
+++ b/src/data/PartyPlatformDataSeniors.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { HOMEOWNERS, SENIORS } from "./Constants";
+import { SENIORS } from "./Constants";
 
 export const CONSERVATIVE_SENIORS = {
     party: "Conservative",
@@ -8,13 +8,12 @@ export const CONSERVATIVE_SENIORS = {
     partyPlatforms: [
         {
             
-            text: "Promises to increase the Age Tax Credit by $1,000, available to seniors making less than $87,750"
-        },
-        {
-            text: "Promises to keep old age security at 65",
+            text: "Promises to increase the Age Tax Credit by $1,000, available to seniors making less than $87,750",
+            source: "https://www.conservative.ca/andrew-scheer-will-give-more-support-to-seniors/",
         },
         {
             text: "Make federally regulated companies disclose the solvency of their pension funds and allow for transfers from pension plans",
+            source: "https://www.theglobeandmail.com/business/article-conservatives-target-executive-payouts-in-bankrupt-companies-with/",
         },
     ],
 };
@@ -25,12 +24,15 @@ export const LIBERAL_SENIORS = {
     partyPlatforms: [
         {
             text: "Boost Old Age Security at age 75 by 10%",
+            source: "https://globalnews.ca/news/5917725/liberals-old-age-security-cpp-trdueau/",
         },
         {
             text: "Increase the Canada Pension Plan by 25% for widows and widowers",
+            source: "https://globalnews.ca/news/5917725/liberals-old-age-security-cpp-trdueau/",
         },
         {
             text: "Want to adjust the Criminal Code with new penalties for elder abuse and to collect better data on how widespread it is",
+            source: "https://2019.liberal.ca/our-platform/elder-abuse/",
         },
     ],
 };
@@ -40,13 +42,12 @@ export const NDP_SENIORS = {
     partyPlatforms: [
         {
             text: "Create a national seniors strategy, which would include a strategy for dementia and a prevention plan for elder abuse",
+            source: "https://www.ndp.ca/news/ndp-statement-national-seniors-day-0",
         },
         {
             text: "Make the Caregiver Tax Credit refundable, to help those who look after seniors",
+            source: "https://business.financialpost.com/personal-finance/taxes/these-are-the-tax-proposals-that-could-affect-your-bottom-line-this-election",
             
-        },
-        {
-            text: "Make automatic enrollment in the Old Age Security and the Guaranteed Income Supplement retroactive",
         },
     ],
 };
@@ -56,12 +57,15 @@ export const GREEN_SENIORS = {
     partyPlatforms: [
         {
             text: "Develop a national seniors strategy that includes a national dementia strategy",
+            source: "https://www.greenparty.ca/en/statement/2019-10-01/green-party-statement-seniors-day",
         },
         {
-            text: "Wants more long-term care beds in neighbourhood facilities"
+            text: "Wants more long-term care beds in neighbourhood facilities",
+            source: "https://www.greenparty.ca/en/platform/renew-social-contract#respecting-and-supporting-seniors",
         },
         {
-            text: "Boost the CPP’s target income replacement rate from 25 to 50% of income made"
+            text: "Boost the CPP’s target income replacement rate from 25 to 50% of income made",
+            source: "https://www.greenparty.ca/en/platform/renew-social-contract#respecting-and-supporting-seniors",
         },
     ],
 };
@@ -71,9 +75,11 @@ export const BLOC_QUEBECOIS_SENIORS = {
     partyPlatforms: [
         {
             text: "Make the Caregiver Tax Credit refundable",
+            source: "https://election.ctvnews.ca/security-housing-pharmacare-this-is-what-each-party-is-promising-seniors-1.4618897",
         },
         {
             text: "Wants anyone 65 and older automatically enrolled in the guaranteed income supplement and increase the supplement",
+            source: "https://election.ctvnews.ca/security-housing-pharmacare-this-is-what-each-party-is-promising-seniors-1.4618897",
         },
     ],
 };

--- a/src/data/PartyPlatformDataSeniors.js
+++ b/src/data/PartyPlatformDataSeniors.js
@@ -108,7 +108,6 @@ SENIORS_PLATFORMS
             if (!idea.demographics) {
                 idea.demographics = []
             }
-            idea.demographics.push(HOMEOWNERS)
             idea.demographics.push(SENIORS)
         })
     });


### PR DESCRIPTION
Each proposed claim by each party has a source linking to another website.

See issue #50 for more details.